### PR TITLE
Add GitHub Actions for automatic submodule updates

### DIFF
--- a/.github/SUBMODULE_AUTO_UPDATE.md
+++ b/.github/SUBMODULE_AUTO_UPDATE.md
@@ -1,0 +1,93 @@
+# Submodule Auto Update Setup
+
+このリポジトリでは、`game-src` submoduleの自動更新機能を実装しています。
+
+## 機能
+
+- **定期チェック**: 毎時間、submoduleの更新をチェック
+- **即座更新**: 手動でワークフローを実行可能
+- **自動PR作成**: 更新があった場合、自動でPull Requestを作成
+- **詳細情報**: コミットメッセージと変更内容を含む
+
+## 設定されたトリガー
+
+### 1. 定期実行（cron）
+```yaml
+schedule:
+  - cron: '0 * * * *'  # 毎時間実行
+```
+
+### 2. 手動実行
+GitHub ActionsのUIから「Run workflow」で手動実行可能
+
+### 3. Repository Dispatch（オプション）
+外部からwebhookで実行可能:
+```bash
+curl -X POST \
+  -H "Accept: application/vnd.github.v3+json" \
+  -H "Authorization: token YOUR_TOKEN" \
+  https://api.github.com/repos/USERNAME/REPO/dispatches \
+  -d '{"event_type":"submodule-updated"}'
+```
+
+## ワークフローの動作
+
+1. **チェックアウト**: リポジトリとsubmoduleを取得
+2. **更新チェック**: `git submodule update --remote --merge`
+3. **変更検知**: 変更があるかチェック
+4. **PR作成**: 変更があれば自動でPRを作成
+5. **自動承認**: （オプション）PRを自動承認
+
+## 作成されるPRの内容
+
+- **タイトル**: "Update game-src submodule"
+- **ブランチ**: `update-submodule-{commit-hash}`
+- **内容**: 
+  - 最新コミットのメッセージ
+  - コミットハッシュ
+  - 変更内容の説明
+
+## submoduleリポジトリ側の設定（オプション）
+
+即座に更新をトリガーしたい場合は、submoduleリポジトリに以下のワークフローを追加:
+
+```yaml
+# game-src リポジトリの .github/workflows/notify-parent.yml
+name: Notify Parent Repository
+
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger parent repository update
+        run: |
+          curl -X POST \
+            -H "Accept: application/vnd.github.v3+json" \
+            -H "Authorization: token ${{ secrets.PARENT_REPO_TOKEN }}" \
+            https://api.github.com/repos/USERNAME/tue-ofuro/dispatches \
+            -d '{"event_type":"submodule-updated"}'
+```
+
+## 注意事項
+
+- PRは自動作成されますが、マージは手動で行ってください
+- 大きな変更がある場合は、PRの内容を十分確認してからマージしてください
+- 必要に応じてcronの頻度を調整できます
+
+## トラブルシューティング
+
+### ワークフローが実行されない
+- GitHub Actionsが有効になっているか確認
+- リポジトリのSettingsでActionsの権限を確認
+
+### PRが作成されない
+- `GITHUB_TOKEN`の権限を確認
+- ブランチ保護ルールを確認
+
+### submoduleが更新されない
+- submoduleのリポジトリが公開されているか確認
+- `.gitmodules`のURLが正しいか確認

--- a/.github/workflows/manual-submodule-update.yml
+++ b/.github/workflows/manual-submodule-update.yml
@@ -1,0 +1,81 @@
+name: Manual Submodule Update
+
+on:
+  workflow_dispatch:
+    inputs:
+      force_update:
+        description: '強制的に更新（変更がなくてもPRを作成）'
+        required: false
+        default: 'false'
+        type: boolean
+
+jobs:
+  manual-update:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Git
+        run: |
+          git config --global user.name 'github-actions[bot]'
+          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+
+      - name: Force update submodule
+        run: |
+          cd game-src
+          git fetch origin
+          git reset --hard origin/main
+          cd ..
+          git add game-src
+
+      - name: Check for changes
+        id: check-changes
+        run: |
+          if [ -n "$(git status --porcelain)" ] || [ "${{ inputs.force_update }}" = "true" ]; then
+            echo "changes=true" >> $GITHUB_OUTPUT
+            NEW_COMMIT=$(cd game-src && git rev-parse HEAD)
+            echo "new_commit=$NEW_COMMIT" >> $GITHUB_OUTPUT
+            COMMIT_MESSAGE=$(cd game-src && git log -1 --pretty=format:"%s")
+            echo "commit_message=$COMMIT_MESSAGE" >> $GITHUB_OUTPUT
+          else
+            echo "changes=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Create Pull Request
+        if: steps.check-changes.outputs.changes == 'true'
+        uses: peter-evans/create-pull-request@v5
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: |
+            Manual update: game-src submodule to ${{ steps.check-changes.outputs.new_commit }}
+            
+            Latest commit: ${{ steps.check-changes.outputs.commit_message }}
+            
+            🔧 Manual update by GitHub Actions
+          title: 'Manual update: game-src submodule'
+          body: |
+            ## Manual Submodule Update
+
+            This PR was manually triggered to update the `game-src` submodule.
+
+            **Latest commit:** ${{ steps.check-changes.outputs.commit_message }}
+            **Commit hash:** `${{ steps.check-changes.outputs.new_commit }}`
+            **Force update:** ${{ inputs.force_update }}
+
+            ### Changes
+            - Updated `game-src` submodule to latest version
+            - No manual code changes required
+
+            **🔧 This PR was created by manual GitHub Actions trigger**
+          branch: manual-update-submodule-${{ steps.check-changes.outputs.new_commit }}
+          delete-branch: true
+          base: main
+
+      - name: No changes found
+        if: steps.check-changes.outputs.changes == 'false'
+        run: |
+          echo "No changes found in submodule. Current version is already up to date."

--- a/.github/workflows/update-submodule.yml
+++ b/.github/workflows/update-submodule.yml
@@ -1,0 +1,87 @@
+name: Update Submodule
+
+on:
+  schedule:
+    # 毎時間 submodule の更新をチェック
+    - cron: '0 * * * *'
+  workflow_dispatch: # 手動実行も可能
+  repository_dispatch:
+    types: [submodule-updated]
+
+jobs:
+  update-submodule:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Git
+        run: |
+          git config --global user.name 'github-actions[bot]'
+          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+
+      - name: Check for submodule updates
+        id: check-updates
+        run: |
+          # submodule を最新に更新
+          git submodule update --remote --merge
+          
+          # 変更があるかチェック
+          if [ -n "$(git status --porcelain)" ]; then
+            echo "changes=true" >> $GITHUB_OUTPUT
+            # 新しいコミットハッシュを取得
+            NEW_COMMIT=$(cd game-src && git rev-parse HEAD)
+            echo "new_commit=$NEW_COMMIT" >> $GITHUB_OUTPUT
+            # コミットメッセージを取得
+            COMMIT_MESSAGE=$(cd game-src && git log -1 --pretty=format:"%s")
+            echo "commit_message=$COMMIT_MESSAGE" >> $GITHUB_OUTPUT
+          else
+            echo "changes=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Create Pull Request
+        if: steps.check-updates.outputs.changes == 'true'
+        uses: peter-evans/create-pull-request@v5
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: |
+            Update game-src submodule to ${{ steps.check-updates.outputs.new_commit }}
+            
+            Latest commit: ${{ steps.check-updates.outputs.commit_message }}
+            
+            🤖 Auto-updated by GitHub Actions
+          title: 'Update game-src submodule'
+          body: |
+            ## Submodule Update
+
+            This PR automatically updates the `game-src` submodule to the latest commit.
+
+            **Latest commit:** ${{ steps.check-updates.outputs.commit_message }}
+            **Commit hash:** `${{ steps.check-updates.outputs.new_commit }}`
+
+            ### Changes
+            - Updated `game-src` submodule to latest version
+            - No manual code changes required
+
+            **🤖 This PR was created automatically by GitHub Actions**
+
+            Please review and merge if the changes look good.
+          branch: update-submodule-${{ steps.check-updates.outputs.new_commit }}
+          delete-branch: true
+          base: main
+
+      - name: Auto-approve PR (optional)
+        if: steps.check-updates.outputs.changes == 'true'
+        uses: juliangruber/approve-pull-request-action@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          number: ${{ steps.create-pull-request.outputs.pull-request-number }}
+
+      - name: Notify Slack (optional)
+        if: steps.check-updates.outputs.changes == 'true'
+        run: |
+          echo "Submodule updated! New commit: ${{ steps.check-updates.outputs.new_commit }}"
+          # Slack通知が必要な場合はここに追加


### PR DESCRIPTION
- Add automatic hourly submodule update workflow
- Add manual submodule update workflow with force option
- Auto-create PRs when submodule has new commits
- Include detailed documentation and setup instructions

Features:
- Scheduled checks every hour
- Manual trigger support
- Repository dispatch webhook support
- Automatic PR creation with commit details
- Optional auto-approval

🤖 Generated with [Claude Code](https://claude.ai/code)